### PR TITLE
Removed dependenceis required only under a virtualenv

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -23,8 +23,8 @@ RUN apt -y install jekyll
 ### install man to test man pages locally inside container
 RUN apt -y install less man
 
+### install xephyr to run GUI
+RUN apt -y install xserver-xephyr
 ### install ggpg dependencies
 RUN apt -y install python3-gi python3-gi-cairo gir1.2-gtk-3.0 python3-pip
-RUN pip3 install pygobject && \
-    pip3 install vext && \
-    pip3 install vext.gi
+RUN pip3 install pygobject

--- a/README.md
+++ b/README.md
@@ -15,9 +15,11 @@
 
   - Fix the settings: `cd /var/ds/ggpg-bionic/ ; vim settings.sh`
 
-  - Get the proper branch of *ggpg*: `git clone --branch gnupg-2.2 https://github.com/easygnupg/ggpg`
+  - Get the proper branch of *ggpg*: `git clone --branch prototype https://github.com/easygnupg/ggpg`
 
   - Create the container: `ds make`
+
+  - Run the application ``python3 main.py``
 
 
 ## Other commands


### PR DESCRIPTION
``vext`` was only needed to by-pass the [--system-site-packages](https://github.com/stuaxo/vext) issue with gi under a virtualenv. In a fresh environment with ``python3`` and  ``python3-gi` it is not required.

Also, I am not sure whether this is correct, but adding ``apt -y install xerver-xephyr`` to the Dockerfile fixed the error ``No protocol specified`` when trying to run the GUI app from the container; although GUIs still can't be run.